### PR TITLE
esn-frontend-inbox#143: Changed the logic of the downloadEmlFile method of inboxJamesMailRepository to adapt to the new jamesApiClient factory that uses esn-api-client

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
   stages {
     stage('Install packages') {
       steps {
-        sh 'npm install'
+        sh 'npm install -f'
       }
     }
 

--- a/src/app/mail-repository/inbox-james-mail-repository.service.js
+++ b/src/app/mail-repository/inbox-james-mail-repository.service.js
@@ -9,6 +9,7 @@ function inboxJamesMailRepository(
   $q,
   $modal,
   $rootScope,
+  FileSaver,
   InboxJamesMailRepositoryEmail,
   jamesApiClient,
   session,
@@ -17,7 +18,7 @@ function inboxJamesMailRepository(
   INBOX_JAMES_MAIL_REPOSITORY_EMAIL_FIELDS,
   INBOX_JAMES_MAIL_REPOSITORY_EVENTS
 ) {
-  var DOMAIN_ID = session.domain._id;
+  const DOMAIN_ID = session.domain._id;
 
   return {
     deleteAllMails: deleteAllMails,
@@ -28,7 +29,16 @@ function inboxJamesMailRepository(
   };
 
   function downloadEmlFile(mailRepository, emailKey) {
-    jamesApiClient.downloadEmlFileFromMailRepository(DOMAIN_ID, mailRepository, emailKey);
+    return jamesApiClient.downloadEmlFileFromMailRepository(DOMAIN_ID, mailRepository, emailKey)
+      .then(data => {
+        try {
+          const emlData = new Blob([data], { type: 'text/html' });
+
+          FileSaver.saveAs(emlData, [emailKey, 'eml'].join('.'));
+        } catch (err) {
+          return $q.reject(err);
+        }
+      });
   }
 
   function deleteMails(emails) {


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/143. Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-inbox/pull/151 because this PR needs to be merged after that PR.

The CI is expected to fail until https://github.com/OpenPaaS-Suite/esn-frontend-inbox/pull/151 is merged.